### PR TITLE
adding a requirements.txt file to improve setup process

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pycryptodomex


### PR DESCRIPTION
As I also stumbled over the correct name for the required library: Since a while requirements.txt files are common as helper to install required packages. Even few IDEs (like PyCharm) will detect such a file and help you to install missing ones. Otherwise you normally use:

pip install -r requirements.txt

It's a very small improvement. One could also specify a minimum version, but I don't know which one to choose.
